### PR TITLE
Fix typo.

### DIFF
--- a/eventstreams127.md
+++ b/eventstreams127.md
@@ -21,7 +21,7 @@ subcollection: eventstreams
 # Connecting to {{site.data.keyword.messagehub}}
 {: #connecting}
 
-The way you connect to {{site.data.keyword.messagehub}} varies depending on whether you're application is running natively or as a Cloud Foundry application. However, in both cases two pieces of information are required: 
+The way you connect to {{site.data.keyword.messagehub}} varies depending on whether your application is running natively or as a Cloud Foundry application. However, in both cases two pieces of information are required: 
 {: shortdesc}
 
 * The endpoint URLs for the APIs


### PR DESCRIPTION
`you're` -> `your`