### PR TITLE
Remove prefix of space character

### DIFF
--- a/index.md
+++ b/index.md
@@ -100,7 +100,7 @@ To access other {{site.data.keyword.messagehub}} samples, including samples for 
    The sample application is stored in Github. Clone the `event-streams-samples` repository by running the clone command from the command line. 
 
    ```
-    git clone https://github.com/ibm-messaging/event-streams-samples.git
+   git clone https://github.com/ibm-messaging/event-streams-samples.git
    ```
    {: codeblock}
 


### PR DESCRIPTION
Remove the space character that prefixes the `git clone` command.